### PR TITLE
Set global sign out cookie security using federation cookiehandler configuration

### DIFF
--- a/src/Libraries/Thinktecture.IdentityServer.Protocols/Shared/SignInSessionsManager.cs
+++ b/src/Libraries/Thinktecture.IdentityServer.Protocols/Shared/SignInSessionsManager.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IdentityModel.Services.Configuration;
 using System.Linq;
 using System.Web;
 
@@ -95,7 +96,7 @@ namespace Thinktecture.IdentityServer.Protocols
 
             var cookie = new HttpCookie(_cookieName, realmString)
             {
-                Secure = true,
+                Secure = SystemIdentityModelServicesSection.DefaultFederationConfigurationElement.CookieHandler.RequireSsl,
                 HttpOnly = true,
                 Path = HttpRuntime.AppDomainAppVirtualPath
             };

--- a/src/Libraries/Thinktecture.IdentityServer.Protocols/Thinktecture.IdentityServer.Protocols.csproj
+++ b/src/Libraries/Thinktecture.IdentityServer.Protocols/Thinktecture.IdentityServer.Protocols.csproj
@@ -42,6 +42,7 @@
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.IdentityModel" />
     <Reference Include="System.IdentityModel.Services" />


### PR DESCRIPTION
I believe that the idsrvauth cookie and the wsfedsignout cookie should follow the same security setting. This will default to RequireSsl = true, but make it possible to disable this for development and test purposes.
