### PR TITLE
Add support for easier renaming of connection string

### DIFF
--- a/src/Libraries/Thinktecture.IdentityServer.Core.Repositories/IdentityServerConfigurationContext.cs
+++ b/src/Libraries/Thinktecture.IdentityServer.Core.Repositories/IdentityServerConfigurationContext.cs
@@ -39,6 +39,10 @@ namespace Thinktecture.IdentityServer.Repositories.Sql
         public IdentityServerConfigurationContext()
             : base("name=IdentityServerConfiguration")
         { }
+        
+        public IdentityServerConfigurationContext(String nameOrConnectionString)
+            : base(nameOrConnectionString)
+        { }
 
         public IdentityServerConfigurationContext(DbConnection conn) : base(conn, true)
         {

--- a/src/Libraries/Thinktecture.IdentityServer.Core.Repositories/IdentityServerConfigurationContext.cs
+++ b/src/Libraries/Thinktecture.IdentityServer.Core.Repositories/IdentityServerConfigurationContext.cs
@@ -35,9 +35,14 @@ namespace Thinktecture.IdentityServer.Repositories.Sql
         public DbSet<StoredGrant> StoredGrants { get; set; }
 
         public static Func<IdentityServerConfigurationContext> FactoryMethod { get; set; }
+        private static String _connectionStringName = "IdentityServerConfiguration";
+        public static String ConnectionStringName {
+            get { return _connectionStringName; }
+            set { _connectionStringName = value; }
+        }
 
         public IdentityServerConfigurationContext()
-            : base("name=IdentityServerConfiguration")
+            : base(_connectionStringName)
         { }
         
         public IdentityServerConfigurationContext(String nameOrConnectionString)
@@ -57,7 +62,7 @@ namespace Thinktecture.IdentityServer.Repositories.Sql
         {
             if (FactoryMethod != null) return FactoryMethod();
 
-            return new IdentityServerConfigurationContext();
+            return new IdentityServerConfigurationContext(ConnectionStringName);
         }
 
         protected override void OnModelCreating(DbModelBuilder modelBuilder)


### PR DESCRIPTION
In our project, I wanted to easily be able to switch between identity provider databases.

It was currently possible by generating a DbConnection, but that forces us to bind to one particular DB provider.

By allowing the Db Name or ConnectionString to be passed in, we allow a much simpler, and more resilient method by which to specify the connection string